### PR TITLE
tweak ISR config on /api/companies route

### DIFF
--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -7,8 +7,9 @@ const COMPANIES_GRID_VIEW = 'Grid view';
 
 const base = new Airtable({ apiKey }).base(SOFTWARE_X_CLIMATE_COMPANIES_BASE_ID);
 
+
 export async function GET() {
-    const records = await base(COMPANIES_TABLE_NAME).select({ view: COMPANIES_GRID_VIEW }).all();
+    const records = await base(COMPANIES_TABLE_NAME).select({ view: COMPANIES_GRID_VIEW }).filter();
 
     // eslint-disable-next-line no-console
     console.log('Fetching records from Airtable...');
@@ -25,3 +26,7 @@ export async function GET() {
 
     return Response.json({ data: companies });
 }
+
+// Tell next.js to revalidate every time this page is fetched
+// https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
+export const revalidate = 0;

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -26,6 +26,6 @@ export async function GET() {
     return Response.json({ data: companies });
 }
 
-// Tell next.js to revalidate every 10 seconds
+// Disable ISR for this route - airtable data could change at any time.
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 10;
+export const revalidate = 0;

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -7,7 +7,6 @@ const COMPANIES_GRID_VIEW = 'Grid view';
 
 const base = new Airtable({ apiKey }).base(SOFTWARE_X_CLIMATE_COMPANIES_BASE_ID);
 
-
 export async function GET() {
     const records = await base(COMPANIES_TABLE_NAME).select({ view: COMPANIES_GRID_VIEW }).all();
 

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -26,6 +26,6 @@ export async function GET() {
     return Response.json({ data: companies });
 }
 
-// Tell next.js to revalidate every time this page is fetched
+// Tell next.js to revalidate every 10 seconds
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate
-export const revalidate = 0;
+export const revalidate = 10;

--- a/src/app/api/companies/route.ts
+++ b/src/app/api/companies/route.ts
@@ -9,7 +9,7 @@ const base = new Airtable({ apiKey }).base(SOFTWARE_X_CLIMATE_COMPANIES_BASE_ID)
 
 
 export async function GET() {
-    const records = await base(COMPANIES_TABLE_NAME).select({ view: COMPANIES_GRID_VIEW }).filter();
+    const records = await base(COMPANIES_TABLE_NAME).select({ view: COMPANIES_GRID_VIEW }).all();
 
     // eslint-disable-next-line no-console
     console.log('Fetching records from Airtable...');


### PR DESCRIPTION
It looks like somehow our call to Airtable is triggering ISR (incremental static rendering) caching, in such a way that causes this endpoint to be cached indefinitely.

Setting a `revalidate` value causes the cache to refresh. We have 2 options here:
1. setting `revalidate` to 0 disables ISR entirely, so we hit airtable (cost: ~250ms) every time the page loads. This is the version deployed [here](https://software-x-climate-px1go35j9-option-zero.vercel.app/) and also the version I'm recommending.
2. set `revalidate` to some number of seconds (10). This means that if somebody loads the page and the cache is >10s old, then _the cached version will still be sent to the user_ but the server will go about refreshing the cache behind the scenes. The upside of this is that loading is always fast (20-40ms), the downside is that the unlucky first user gets the stale cached version. This seems like a bad choice. This is the version deployed [here](https://software-x-climate-ne1qpzzus-option-zero.vercel.app/), and I hope to check it tomorrow morning and see that it's broken.

We actually have a third option also which is to enable ISR, but push a signal from Airtable anytime the base is updated (or just push periodically from a cron job). To reset the cache, we would trigger a route that calls [`revalidatePath()`](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#on-demand-revalidation)

## Manual testing

Current version on `main`: cache is always a `HIT`
![image](https://github.com/Option-Zero/software-x-climate/assets/3341011/733731c9-faf2-4097-857f-992387e459f4)

with option 1, it is always a `MISS` and takes ~250ms
with option 2, it a `HIT` if the cache is <10s old but it is `STALE` for the first request after the 10s expiration. After that it becomes a `HIT` again
![image](https://github.com/Option-Zero/software-x-climate/assets/3341011/6f61a44f-ce05-4b29-be0f-9067a9c675c2)
example `STALE` cache. this request still only takes 30ms, indicating that Vercel happily served up the stale version. Seems kinda stupid to me.
![image](https://github.com/Option-Zero/software-x-climate/assets/3341011/57c0403a-b514-4d54-b2fd-ab437602cbc8)
