### PR TITLE
Add informative metadata for showcase page

### DIFF
--- a/src/app/showcase/layout.tsx
+++ b/src/app/showcase/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: 'Projects Showcase - Software for Climate',
+    description:
+        'Explore innovative climate tech projects from the Software for Climate fellowship. Browse projects by cohort, discover solutions tackling emissions reduction, climate adaptation, and sustainability challenges.',
+    openGraph: {
+        title: 'Projects Showcase - Software for Climate',
+        description:
+            'Explore innovative climate tech projects from the Software for Climate fellowship. Browse projects by cohort, discover solutions tackling emissions reduction, climate adaptation, and sustainability challenges.',
+        type: 'website',
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title: 'Projects Showcase - Software for Climate',
+        description:
+            'Explore innovative climate tech projects from the Software for Climate fellowship. Browse projects by cohort.',
+    },
+};
+
+export default function ShowcaseLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return <>{children}</>;
+}

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -63,11 +63,6 @@ export default function ShowcasePage() {
         fetchAndHandleAnchor();
     }, []);
 
-    // Set page title
-    useEffect(() => {
-        document.title = 'Projects Showcase - Software for Climate';
-    }, []);
-
     const groupedProjects = groupProjectsByCohort(projects);
     const cohorts = groupedProjects.map((g) => g.cohort);
 


### PR DESCRIPTION
Add a layout.tsx with proper SEO metadata including title, description,
OpenGraph, and Twitter card tags that describe the page's purpose -
showcasing climate tech projects from the fellowship program.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds framework-native SEO metadata for the showcase page and cleans up redundant client-side title handling.
> 
> - New `src/app/showcase/layout.tsx` exporting Next.js `metadata` with title, description, OpenGraph, and Twitter card
> - Remove manual `document.title` `useEffect` from `src/app/showcase/page.tsx`; no other UI/logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0529202188c0f7473e6511ea748dcd12c0464571. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->